### PR TITLE
Rename site and docs to project group terminology

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# [Your Working Group Name]
+# [Your Project Group Name]
 
-Welcome to the [Your Working Group Name] repository, part of the Environmental Data Science Innovation and Inclusion Lab (ESIIL). This repository serves as the central hub for our working group, hosting our project description, proposals, member bios, codebase, and more.
+Welcome to the [Your Project Group Name] repository, part of the Environmental Data Science Innovation and Inclusion Lab (ESIIL). This repository serves as the central hub for our project group, hosting our project description, proposals, member bios, codebase, and more.
 
 test edit 
 
@@ -46,7 +46,7 @@ If you encounter any issues or have questions about how to contribute, please re
 
 ## Customize Your Repository
 
-As a new working group, you'll want to make this repository your own. Here's how to get started:
+As a new project group, you'll want to make this repository your own. Here's how to get started:
 
 1. **Edit This Readme**: Replace the placeholder content with information about your specific project. Ensure that the introduction, project overview, and objectives clearly reflect your group's research focus.
 
@@ -68,5 +68,5 @@ As a new working group, you'll want to make this repository your own. Here's how
 
 10. **Establish Communication Channels**: Beyond GitHub, set up additional communication channels like Slack, Discord, or email lists for quick and informal discussions.
 
-Remember, the goal is to make your repository clear, accessible, and useful for all current and future members of your working group. Happy researching!
+Remember, the goal is to make your repository clear, accessible, and useful for all current and future members of your project group. Happy researching!
 

--- a/docs/orientation/code-of-conduct.md
+++ b/docs/orientation/code-of-conduct.md
@@ -14,9 +14,9 @@ As such, our core values center people through inclusion, kindness, respect, col
 
 ### When and how to use these guidelines
 
-These guidelines outline behavior expectations for ESIIL community members. Your participation in the ESIIL network is contingent upon following these guidelines in all ESIIL activities, including, but not limited to, participating in meetings, webinars, hackathons, working groups, hosted or funded by ESIIL, as well as email lists and online forums such as GutHub, Slack, and Twitter. These guidelines have been adapted from those of the International Arctic Research Policy Committee, the Geological Society of America, the American Geophysical Union, the University Corporation for Atmospheric Research, The Carpentries, and others. We encourage other organizations to adapt these guidelines for use in their own meetings.
+These guidelines outline behavior expectations for ESIIL community members. Your participation in the ESIIL network is contingent upon following these guidelines in all ESIIL activities, including, but not limited to, participating in meetings, webinars, hackathons, project groups, hosted or funded by ESIIL, as well as email lists and online forums such as GutHub, Slack, and Twitter. These guidelines have been adapted from those of the International Arctic Research Policy Committee, the Geological Society of America, the American Geophysical Union, the University Corporation for Atmospheric Research, The Carpentries, and others. We encourage other organizations to adapt these guidelines for use in their own meetings.
 
-**Note:** Working groups and hackathon/codefest teams are encouraged to discuss these guidelines and what they mean to them, and will have the opportunity to add to them to specifically support and empower their team. Collaborative and behavior commitments complement data use, management, authorship, and access plans that commit to CARE and FAIR principles.
+**Note:** Project groups and hackathon/codefest teams are encouraged to discuss these guidelines and what they mean to them, and will have the opportunity to add to them to specifically support and empower their team. Collaborative and behavior commitments complement data use, management, authorship, and access plans that commit to CARE and FAIR principles.
 
 # Behavior Agreements
 

--- a/docs/orientation/esiil_training.md
+++ b/docs/orientation/esiil_training.md
@@ -1,8 +1,8 @@
-# ESIIL Working Groups training sessions
+# ESIIL Project Groups training sessions
 
 ## Introduction to ESIIL Training
 - Brief overview of the training program.
-- Objectives and expected outcomes for the working groups.
+- Objectives and expected outcomes for the project groups.
 
 ## Session 1: The Science of Team Science (2 Hours)
 ### Part 1: Creating Ethical and Innovative Work Spaces

--- a/docs/orientation/slides.md
+++ b/docs/orientation/slides.md
@@ -1,6 +1,6 @@
 # Welcome to ESIIL Education Student OASIS
 
-This is the central resource for ESIIL working groups.
+This is the central resource for ESIIL project groups.
 
 ## Embedded Website
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,11 @@
-site_name: 'ESIIL Working Group OASIS'
-site_description: 'Central resource for ESIIL working groups'
+site_name: 'ESIIL Project Group OASIS'
+site_description: 'Central resource for ESIIL project groups'
 site_author: Ty Tuff
-site_url: https://cu-esiil.github.io/Working_group_home
+site_url: https://cu-esiil.github.io/Project_group_home
 
 # Repository
-repo_name: Working-group-home
-repo_url: https://github.com/CU-ESIIL/Working_group_oasis
+repo_name: Project-group-home
+repo_url: https://github.com/CU-ESIIL/Project_group_oasis
 edit_uri: edit/main/docs/
 # Copyright
 copyright: 'Copyright &copy; 2024 University of Colorado Boulder'


### PR DESCRIPTION
## Summary
- Retitle site configuration to "ESIIL Project Group OASIS" and adjust description and repo name
- Switch orientation materials and templates from "working group" to "project group"
- Update code of conduct and training docs to reference project groups

## Testing
- `pip install -r requirements.txt`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68c1f21c6ff083259aa8ac7f590057e1