### PR TITLE
Add 3-day sprint instructions section

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,7 @@
+header_pages:
+  - index.md
+  - updates.md
+  - team.md
+  - code.md
+  - data.md
+  - instructions.md

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Instructions
+permalink: /instructions/
+---
+
+# Instructions: 3-Day Science Sprint
+
+Welcome! These guides help your team use this site as a live, visual record of your sprint. Each day has clear prompts and short, practical steps.
+
+- **Day 1 →** [Define & Explore](instructions/day1.md)  
+- **Day 2 →** [Data & Methods](instructions/day2.md)  
+- **Day 3 →** [Insights & Sharing](instructions/day3.md)
+
+> Tip: Edit any page in your browser: open the file → click the pencil (✎) → make changes → **Commit changes**.

--- a/docs/instructions/day1.md
+++ b/docs/instructions/day1.md
@@ -1,0 +1,71 @@
+---
+layout: page
+title: Day 1 — Define & Explore
+permalink: /instructions/day1/
+---
+
+# Day 1 — Define & Explore
+**Focus:** get to know each other, define the question and hypotheses, and make your first edits to the website. Try a simple Git pull/push from CyVerse if you have time.
+
+## 1) Start with people
+- Names, roles, what each person wants to learn or contribute in 3 days.
+- Add your names to **[Team](../team.md)** (top nav → Team). Edit the table, keep it simple.
+
+## 2) Define your question(s) and hypotheses
+Open **Home** → edit `docs/index.md` → fill in:
+- **Our question(s)**: 2–4 bullets; invite divergent framings.
+- **Hypotheses / intentions**: short, plain-language "we think…" statements.
+- **Why this matters (upshot)**: who benefits and how decisions could change.
+
+> Keep text short. One strong visual per section is ideal.
+
+## 3) Add a quick visual (whiteboard/smartphone photo)
+- Take a photo of your whiteboard or notes.
+- Upload to `docs/assets/` (Code tab → docs → assets → **Add file → Upload files**).
+- Reference it in `docs/index.md` under **Field notes / visuals**:
+  ```markdown
+  ![Whiteboard brainstorm](assets/day1_whiteboard.jpg)
+  *Caption: What this shows and why it’s useful today.*
+  ```
+
+* **Commit changes** to publish.
+
+## 4) Optional: try Git pull/push from CyVerse (basic)
+
+> If you’re using a CyVerse Jupyter environment and want to sync with GitHub.
+
+**Clone the repo (HTTPS is easiest for beginners):**
+
+```bash
+# In your CyVerse terminal
+cd ~
+# Replace with your repo URL (green "Code" button → HTTPS)
+git clone https://github.com/ORG/REPO.git
+cd REPO
+```
+
+**Make a tiny change and push it back:**
+
+```bash
+echo "hello from cyverse $(date)" >> docs/updates.md
+git add docs/updates.md
+git commit -m "Add Day 1 note from CyVerse"
+# You may be prompted for GitHub credentials (use a Personal Access Token if needed)
+git push origin main
+```
+
+**Pull the latest changes (when others edit in the browser):**
+
+```bash
+git pull origin main
+```
+
+> If HTTPS auth is confusing, it’s fine to edit in the browser only. You can learn SSH keys later.
+
+## 5) Day 1 checklist
+
+* [ ] Team added to **Team** page.
+* [ ] Questions, hypotheses, and upshot filled in on **Home**.
+* [ ] One visual added (whiteboard/notes photo).
+* [ ] (Optional) CyVerse: cloned repo and pushed a small change.
+

--- a/docs/instructions/day2.md
+++ b/docs/instructions/day2.md
@@ -1,0 +1,65 @@
+---
+layout: page
+title: Day 2 — Data & Methods
+permalink: /instructions/day2/
+---
+
+# Day 2 — Data & Methods
+**Focus:** try a few datasets and analyses. Keep it visual, keep it simple. Update the site to reflect what you test.
+
+## 1) Explore the Data Library & Analytics Library
+- Browse your **Data Library** for candidate datasets (portals, STAC catalogs, archives). Capture links and notes.
+- Browse your **Analytics Library** for example workflows (scripts, notebooks).
+- Log 2–4 promising items on **Home** → `docs/index.md` under:
+  - **Data sources we’re exploring** (links + 1-line notes)
+  - **Methods / technologies we’re testing** (stats, models, viz)
+
+## 2) Transfer or access data via gocmd (if needed)
+> Use when moving files to/from institutional storage (e.g., CyVerse Data Store).
+
+**Install & initialize gocmd (Linux):**
+```bash
+# Download latest gocmd and extract
+GOCMD_VER=$(curl -L -s https://raw.githubusercontent.com/cyverse/gocommands/main/VERSION.txt); \
+curl -L -s https://github.com/cyverse/gocommands/releases/download/${GOCMD_VER}/gocmd-${GOCMD_VER}-linux-amd64.tar.gz | tar zxvf -
+
+# Initialize and verify identity
+./gocmd init
+./gocmd whoami
+```
+
+**Example transfers:**
+
+```bash
+# Upload a local file to the Data Store
+./gocmd put ./outputs/figure1.png /iplant/home/YOUR_USER/sprint/figure1.png
+
+# Download from the Data Store to your working dir
+./gocmd get /iplant/home/YOUR_USER/sprint/input.csv ./data/input.csv
+```
+
+> Keep large data out of GitHub. Store externally, link from the **Data** page.
+
+## 3) Show early results (visual-first)
+
+* Add **Prototype visuals** on **Home** → `docs/index.md`:
+
+  * A static figure (PNG)
+  * A small GIF for change over time (if you have one)
+  * An iframe map or relevant portal view
+* Add brief captions: what it shows and why it matters.
+
+## 4) Link runnable code
+
+* Put scripts/notebooks in `src/`.
+* On **Code** (`docs/code.md`), add a short entry per script: what it does, inputs, how to run.
+* Keep names clear: `src/pipeline.py`, `src/notebooks/explore.ipynb`.
+
+## 5) Day 2 checklist
+
+* [ ] 2–4 data sources listed with links on **Home**.
+* [ ] 1–2 methods listed on **Home**.
+* [ ] At least one prototype visual added.
+* [ ] Code linked from **Code** page.
+* [ ] Large files moved via gocmd (or linked externally).
+

--- a/docs/instructions/day3.md
+++ b/docs/instructions/day3.md
@@ -1,0 +1,43 @@
+---
+layout: page
+title: Day 3 — Insights & Sharing
+permalink: /instructions/day3/
+---
+
+# Day 3 — Insights & Sharing
+**Focus:** synthesize what you learned, polish visuals, and create a short, public-facing story. Make a plan for next steps.
+
+## 1) Findings at a glance
+- On **Home** → `docs/index.md`, write 2–4 **headline bullets** in plain language.
+- Include one number if possible (change, contrast, uncertainty note).
+
+## 2) Visuals that tell the story
+- Choose **2–3 strongest visuals**: maps/plots/GIFs. Replace placeholders in **Home**.
+- Ensure captions say: *what it shows* and *why it matters*.
+
+## 3) Produce a 1–2 page brief (optional but encouraged)
+- Export a short PDF (figures + bullets). Link it from the **Home** hero section.
+- Keep it readable for non-experts.
+
+## 4) Plan what’s next
+- In **Home → What’s next?** add 3–5 bullets:
+  - Immediate follow-ups (1–2 weeks)
+  - If we had one more month…
+  - Who should see this next (stakeholders)
+
+## 5) Polish & acknowledge
+- Add team details to **Team** page.
+- Add any citations to **Cite & reuse** on **Home**.
+- Verify licenses (code and data) are stated.
+
+## 6) Report-out prep
+- Practice a **2-minute walkthrough** of the homepage: Why → Questions → Data/Methods → Findings → Next.
+- If you made a short video or recorded demo, embed with an iframe on **Home**.
+
+## Day 3 checklist
+- [ ] Headline findings posted on **Home**.
+- [ ] 2–3 polished visuals with captions.
+- [ ] Brief PDF linked (if created).
+- [ ] Next steps listed.
+- [ ] Team/citations/acknowledgments complete.
+- [ ] Walkthrough rehearsed.


### PR DESCRIPTION
## Summary
- Add Instructions landing page with links to three day-by-day guides
- Provide Day 1-3 pages for defining goals, exploring data, and sharing insights
- Update site config to show Instructions in navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1ffc1d27c83259ddc3bf728f7d8bc