### PR TITLE
Add team photo to Day 3 section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -112,6 +112,9 @@ Explain who is impacted and how this could change decisions or understanding.
 ## Day 3 — Insights & Sharing
 *Focus: synthesis; highlight 2–3 visuals that tell the story; keep text crisp.*
 
+![Team photo at start of Day 3](assets/team_photo.jpg)
+[Raw photo location: team_photo.jpg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/team_photo.jpg)
+
 ### Findings at a glance
 <!-- EDIT: 2–4 bullets, each a headline in plain language with a number if possible. -->
 - Headline 1 — what, where, how much


### PR DESCRIPTION
## Summary
- Display team photo at start of Day 3 on the homepage.

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68c355f989c8832594a31c01964b58f4