### PR TITLE
Add persistent storage and GitHub directions

### DIFF
--- a/docs/instructions/push-to-github.md
+++ b/docs/instructions/push-to-github.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Push to GitHub
+permalink: /instructions/push/
+---
+
+# Push to GitHub
+
+Commit and push your work so teammates can see updates.
+
+```bash
+# After editing files
+git add .
+git commit -m "Describe your changes"
+git push origin main
+```
+
+Use `git pull origin main` to sync changes from others before you start working.

--- a/docs/instructions/save-to-persistent-storage.md
+++ b/docs/instructions/save-to-persistent-storage.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Save to persistent storage
+permalink: /instructions/save/
+---
+
+# Save to persistent storage
+
+Store shared data in the group data store folder so it persists after the sprint.
+
+- **CyVerse Data Store path:** `/iplant/home/shared/esiil/Innovation_summit/Group_1` (replace `Group_1` with your group name).
+- **Web link:** [CyVerse Data Store folder](https://de.cyverse.org/data/ds/iplant/home/shared/esiil/Innovation_summit/Group_1?type=folder&resourceId=1993057e-8e90-11f0-b0fa-90e2ba675364)
+
+Upload files here from CyVerse or the web interface so everyone can access them later.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,8 @@ nav:
        - Day 1 — Define & Explore: instructions/day1.md
        - Day 2 — Data & Methods: instructions/day2.md
        - Day 3 — Insights & Sharing: instructions/day3.md
+       - Save to persistent storage: instructions/save-to-persistent-storage.md
+       - Push to GitHub: instructions/push-to-github.md
   - Orientation:
        - Orientation Slides: orientation/slides.md
        - Code of Conduct: orientation/code-of-conduct.md


### PR DESCRIPTION
## Summary
- Add "Save to persistent storage" and "Push to GitHub" instructions
- Link persistent storage to CyVerse Data Store folder
- Update navigation sidebar to include new directions

## Testing
- `pytest`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c42999ab7083258efad9703b9d319d