### PR TITLE
Add CyVerse launch badge to instance docs

### DIFF
--- a/docs/code/data_processing.md
+++ b/docs/code/data_processing.md
@@ -14,6 +14,7 @@ This is my draft text
 List and describe data sources used, including links to cloud-optimized sources. Highlight permissions and compliance with data ownership guidelines.
 
 ## CyVerse Discovery Environment
+[![Launch in CyVerse DE](https://img.shields.io/badge/Launch-CyVerse%20DE-0b6efd?style=flat-square)](https://de.cyverse.org/apps/de/faf1d268-44cc-11ed-9715-008cfa5ae621/launch?saved-launch-id=dc65718e-1964-4d11-99ad-bf901cddda99)
 Instructions for setting up and using the CyVerse Discovery Environment for data processing. Tips for cloud-based data access and processing.
 
 ## Data Processing Steps

--- a/docs/instructions/day1.md
+++ b/docs/instructions/day1.md
@@ -34,6 +34,8 @@ Open **Home** → edit `docs/index.md` → fill in:
 
 > If you’re using a CyVerse Jupyter environment and want to sync with GitHub.
 
+[![Launch in CyVerse DE](https://img.shields.io/badge/Launch-CyVerse%20DE-0b6efd?style=flat-square)](https://de.cyverse.org/apps/de/faf1d268-44cc-11ed-9715-008cfa5ae621/launch?saved-launch-id=dc65718e-1964-4d11-99ad-bf901cddda99)
+
 **Clone the repo (HTTPS is easiest for beginners):**
 
 ```bash

--- a/docs/instructions/link-to-github.md
+++ b/docs/instructions/link-to-github.md
@@ -10,6 +10,8 @@ This page walks you through generating an SSH key inside JupyterHub and adding i
 
 > **Prereq:** Open a **Jupyter Notebook**, paste the code below into a cell, and click the **Run/Play ▶️** button to execute it.
 
+[![Launch in CyVerse DE](https://img.shields.io/badge/Launch-CyVerse%20DE-0b6efd?style=flat-square)](https://de.cyverse.org/apps/de/faf1d268-44cc-11ed-9715-008cfa5ae621/launch?saved-launch-id=dc65718e-1964-4d11-99ad-bf901cddda99)
+
 ---
 
 ## 1) Run this one‑cell setup script in a Notebook

--- a/docs/instructions/push-to-github.md
+++ b/docs/instructions/push-to-github.md
@@ -8,6 +8,8 @@ permalink: /instructions/push/
 
 This page assumes your repository **already exists** and has been cloned into JupyterHub. It also assumes you’ve already set up **SSH authentication** (see the [Link to GitHub](link-to-github.md) page before continuing).
 
+[![Launch in CyVerse DE](https://img.shields.io/badge/Launch-CyVerse%20DE-0b6efd?style=flat-square)](https://de.cyverse.org/apps/de/faf1d268-44cc-11ed-9715-008cfa5ae621/launch?saved-launch-id=dc65718e-1964-4d11-99ad-bf901cddda99)
+
 ---
 
 ## 1) Open the Git panel

--- a/docs/orientation/cyverse_basics.md
+++ b/docs/orientation/cyverse_basics.md
@@ -12,6 +12,8 @@
 
 3. Head over to the Cyverse Discovery Environment [https://de.cyverse.org](https://de.cyverse.org), and log in with your new account.
 
+[![Launch in CyVerse DE](https://img.shields.io/badge/Launch-CyVerse%20DE-0b6efd?style=flat-square)](https://de.cyverse.org/apps/de/faf1d268-44cc-11ed-9715-008cfa5ae621/launch?saved-launch-id=dc65718e-1964-4d11-99ad-bf901cddda99)
+
    <img width="881" alt="image" src="https://github.com/CU-ESIIL/hackathon2023_datacube/assets/3465768/41970a8d-c434-4075-9dd4-fbcd0f2ea07c">
 
    You should now see the Discovery Environment:

--- a/docs/orientation/docker_basics.md
+++ b/docs/orientation/docker_basics.md
@@ -231,6 +231,8 @@ Click on the run workflow dropdown and click Run Workflow
 ## Deploying the Image on CyVerse
 First go to de.cyverse.org and login. From there go to the Apps dashboard and click on Manage Tools.
 
+[![Launch in CyVerse DE](https://img.shields.io/badge/Launch-CyVerse%20DE-0b6efd?style=flat-square)](https://de.cyverse.org/apps/de/faf1d268-44cc-11ed-9715-008cfa5ae621/launch?saved-launch-id=dc65718e-1964-4d11-99ad-bf901cddda99)
+
 ![ManageTools](../assets/docker_basics/manage_tools.png)
 [Raw photo location: manage_tools.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/manage_tools.png)
 


### PR DESCRIPTION
## Summary
- Add "Launch in CyVerse DE" badge to CyVerse login walkthrough
- Embed badge in Docker deployment guide and JupyterHub setup pages
- Include launch badge in day1 instructions and data processing guide

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68c43fdd5e148325bc07c853b1587919