### PR TITLE
Add edit link to index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,8 @@ title: Project Sprint — 3-Day Science Showcase
 permalink: /
 ---
 
+<p style="text-align: right;"><a href="https://github.com/CU-ESIIL/Project_group_OASIS/edit/main/docs/index.md" title="Edit this page">✏️</a></p>
+
 <!-- =========================================================
 HERO (Swap hero.jpg, title, strapline, and the three links)
 ========================================================= -->


### PR DESCRIPTION
## Summary
- add top-right edit pencil link on index page for quick navigation to the GitHub editor

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c497cfc5d08325a52cd2d1dc353dae