### PR TITLE
Update site logo and link

### DIFF
--- a/docs/overrides/partials/logo.html
+++ b/docs/overrides/partials/logo.html
@@ -1,0 +1,8 @@
+<a class="md-header__button md-logo" href="https://cu-esiil.github.io/home/" title="{{ config.site_name }}">
+  {% if config.theme.logo %}
+    <img src="{{ config.theme.logo | url }}" alt="{{ config.site_name }}" />
+  {% else %}
+    {{ config.site_name }}
+  {% endif %}
+</a>
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,8 +33,9 @@ theme:
   font:
     text: 'Open Sans'
     code: 'Roboto Mono'
-  logo: 'assets/esiil_content/ESIIL_logo.png'
+  logo: 'assets/esiil_content/esiil_oasis_logo.png'
   favicon: 'assets/esiil_content/favicon.ico'
+  custom_dir: docs/overrides
   # setting features for the navigation tab
   features:
     - navigation.sections


### PR DESCRIPTION
## Summary
- update the MkDocs configuration to use the new ESIIL OASIS logo asset and enable the theme override directory
- add a theme override that points the header logo to the OASIS homepage

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68cc411006d88325811ac6d9c2c40d2e