### PR TITLE
Add Storage guidance for code and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@ This guide is written for people who may be brand new to GitHub. It will show yo
 Think of this repository like a **shared online folder**. Inside it, there are a few important parts:
 
 * **README.md** — This file (what you are reading now). It explains how things work.
-* **docs/** — This folder powers your website. Everything you put here will show up on the web.
-* **src/** — This folder is where you share your code (scripts, notebooks, analysis).
 * **data/** — Optional. Small datasets can go here.
 * **outputs/** — Optional. Figures, results, and reports can go here.
+
+### Storage
+
+- **Code (`code/`)** — Share scripts, notebooks, and analysis utilities. Keep filenames clear and include short comments at the top so teammates understand the purpose quickly.
+- **Documentation (`docs/` and `documentation/`)** — Everything inside `docs/` powers the public website, while `documentation/` can host internal notes or extended write-ups. Update these areas regularly so the story on the site and your working docs stay in sync.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,16 @@ HERO (Swap hero.jpg, title, strapline, and the three links)
 
 ---
 
+## Storage
+
+### Code
+- Keep shared scripts, notebooks, and utilities in the [`code/`](https://github.com/CU-ESIIL/Project_group_OASIS/tree/main/code) directory. Document how to run them in a README or within the files so teammates and visitors can reproduce your workflow.
+
+### Documentation
+- Use the [`docs/`](https://github.com/CU-ESIIL/Project_group_OASIS/tree/main/docs) folder to publish project updates on this site. Longer internal notes can live in [`documentation/`](https://github.com/CU-ESIIL/Project_group_OASIS/tree/main/documentation); summarize key takeaways here so the public story stays current.
+
+---
+
 ## How to use this page (for the team)
 - **Edit this file:** `docs/index.md` → ✎ → change text → **Commit changes**.
 - **Add images:** upload to `docs/assets/` and reference like `assets/your_file.png`.


### PR DESCRIPTION
## Summary
- emphasize a dedicated **Storage** section in the README to highlight where to keep shared code and documentation
- add a matching Storage section to the website home page so visitors understand where project materials live

## Testing
- python -m compileall code

------
https://chatgpt.com/codex/tasks/task_e_68cc607fb1b88325aec61ac17248ac7a