### PR TITLE
Update gocmd usage guidance

### DIFF
--- a/docs/instructions/day2.md
+++ b/docs/instructions/day2.md
@@ -23,19 +23,24 @@ permalink: /instructions/day2/
 GOCMD_VER=$(curl -L -s https://raw.githubusercontent.com/cyverse/gocommands/main/VERSION.txt); \
 curl -L -s https://github.com/cyverse/gocommands/releases/download/${GOCMD_VER}/gocmd-${GOCMD_VER}-linux-amd64.tar.gz | tar zxvf -
 
-# Initialize and verify identity
+# Initialize and authenticate
 ./gocmd init
-./gocmd whoami
+./gocmd auth login  # follow prompts for CyVerse credentials
+
+# Optionally confirm access to your home directory
+./gocmd ls i:/iplant/home/YOUR_USER
 ```
+
+> Remote Data Store paths must include the `i:` prefix (for example, `i:/iplant/home/...`). Local paths should omit it.
 
 **Example transfers:**
 
 ```bash
 # Upload a local file to the Data Store
-./gocmd put ./outputs/figure1.png /iplant/home/YOUR_USER/sprint/figure1.png
+./gocmd put ./outputs/figure1.png i:/iplant/home/YOUR_USER/sprint/figure1.png
 
 # Download from the Data Store to your working dir
-./gocmd get /iplant/home/YOUR_USER/sprint/input.csv ./data/input.csv
+./gocmd get i:/iplant/home/YOUR_USER/sprint/input.csv ./data/input.csv
 ```
 
 > Keep large data out of GitHub. Store externally, link from the **Data** page.

--- a/docs/instructions/save-to-persistent-storage.md
+++ b/docs/instructions/save-to-persistent-storage.md
@@ -14,12 +14,12 @@ curl -L -s https://github.com/cyverse/gocommands/releases/download/${GOCMD_VER}/
 
 # Configure iRODS (accept defaults for Host/Port/Zone; use your CyVerse creds)
 ./gocmd init
-./gocmd whoami
+./gocmd auth login  # follow prompts to authenticate with CyVerse
 ```
 
 **Community folder root (read/write for teams):**
 ```
-/iplant/home/shared/esiil/Innovation_summit/<GROUP_NAME>
+i:/iplant/home/shared/esiil/Innovation_summit/<GROUP_NAME>
 ```
 
 Set environment variables:

--- a/docs/project_template.md
+++ b/docs/project_template.md
@@ -107,7 +107,7 @@ Project one-liner: _(write it here)_
 GOCMD_VER=$(curl -L -s https://raw.githubusercontent.com/cyverse/gocommands/main/VERSION.txt); \
 curl -L -s https://github.com/cyverse/gocommands/releases/download/${GOCMD_VER}/gocmd-${GOCMD_VER}-linux-amd64.tar.gz | tar zxvf -
 ./gocmd init
-./gocmd whoami
+./gocmd auth login  # follow prompts to authenticate
 ```
 
    > *(macOS uses a different tarball)*


### PR DESCRIPTION
## Summary
- replace the invalid `gocmd` whoami reference with current authentication steps
- document the required `i:` prefix for CyVerse Data Store paths in examples
- add guidance for confirming Data Store access after logging in

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68cc6118d2fc83258eb411c8e7574519