### PR TITLE
Update documentation video references

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -135,7 +135,7 @@ Explain who is impacted and how this could change decisions or understanding.
 <iframe
   title="Short explainer video (optional)"
   width="100%" height="360"
-  src="https://www.youtube.com/embed/dQw4w9WgXcQ"
+  src="https://www.youtube.com/embed/ASTGFZ0d6Ps"
   frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
   allowfullscreen></iframe>
 

--- a/docs/orientation/cyverse_basics.md
+++ b/docs/orientation/cyverse_basics.md
@@ -53,8 +53,8 @@
 ## Set up your GitHub credentials
 
 ### If you would prefer to follow a video instead of a written outline, we have prepared a video here:
-<a href="https://www.youtube.com/watch?v=nOwOzPJEQbU">
-    <img src="https://img.youtube.com/vi/nOwOzPJEQbU/0.jpg" style="width: 100%;">
+<a href="https://www.youtube.com/watch?v=ASTGFZ0d6Ps">
+    <img src="https://img.youtube.com/vi/ASTGFZ0d6Ps/0.jpg" style="width: 100%;">
 </a>
 
 1. From Jupyter Lab, click on the Git Extension icon on the left menu:

--- a/docs/orientation/markdown_basics.md
+++ b/docs/orientation/markdown_basics.md
@@ -151,7 +151,7 @@ Fill in the blank cells with numbers from 1 to 9, such that each row, column, an
   - ![Markdown Logo](https://example.com/markdown-logo.png)
 
 - **Videos**: Embed videos using HTML in Markdown.
-  - `<iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allowfullscreen></iframe>`
+  - `<iframe width="560" height="315" src="https://www.youtube.com/embed/ASTGFZ0d6Ps" frameborder="0" allowfullscreen></iframe>`
 
 ### 4. Diagrams with Mermaid
 


### PR DESCRIPTION
## Summary
- replace the embedded homepage video with the new YouTube link
- refresh the markdown basics example to show the new embed URL
- update the CyVerse orientation video link and thumbnail to the new recording

## Testing
- no tests were run (not required for documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cd75df83c883258d1ada0f1630963a