### PR TITLE
Add bootstrap workflow for template repos

### DIFF
--- a/.github/ISSUE_TEMPLATES/SETUP_COMPLETE.md
+++ b/.github/ISSUE_TEMPLATES/SETUP_COMPLETE.md
@@ -1,0 +1,12 @@
+Your repo is bootstrapped 🎉
+
+**What we did**
+- Set site name to match the repo (humanized)
+- Updated `mkdocs.yml` with site name & URL
+- Updated `docs/index.md` header and resources block
+- Added storage link page if configured
+
+**Next steps**
+- Edit `docs/index.md` to add your project intro
+- Add team members in `docs/team.md`
+- Push any code to `code/` or `src/`

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,0 +1,122 @@
+name: Bootstrap new repo
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pages: write
+  id-token: write
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Derive names
+        id: names
+        run: |
+          REPO="${{ github.event.repository.name }}"
+          OWNER="${{ github.repository_owner }}"
+          # Site title: turn separators into spaces, Title Case via python
+          TITLE=$(python - <<'PY'
+import os,re
+name=os.environ["REPO"]
+name=re.sub(r'__',' ',name)
+name=re.sub(r'[-_]+' ,' ',name)
+title=' '.join(w.capitalize() for w in name.split())
+print(title)
+PY
+)
+          # Extract group id: prefer double-underscore suffix (…__N), fallback to trailing digits
+          if [[ "$REPO" =~ __([0-9]+)$ ]]; then
+            GROUP_ID="${BASH_REMATCH[1]}"
+          elif [[ "$REPO" =~ ([0-9]+)$ ]]; then
+            GROUP_ID="${BASH_REMATCH[1]}"
+          else
+            GROUP_ID=""
+          fi
+          echo "repo=$REPO"         >> $GITHUB_OUTPUT
+          echo "owner=$OWNER"       >> $GITHUB_OUTPUT
+          echo "title=$TITLE"       >> $GITHUB_OUTPUT
+          echo "group_id=$GROUP_ID" >> $GITHUB_OUTPUT
+          echo "site_url=https://$OWNER.github.io/$REPO/" >> $GITHUB_OUTPUT
+
+      - name: Inject storage link (optional)
+        id: storage
+        run: |
+          GROUP_ID="${{ steps.names.outputs.group_id }}"
+          BASE="${{ secrets.COMMUNITY_STORAGE_BASE }}"
+          if [[ -n "$BASE" && -n "$GROUP_ID" ]]; then
+            mkdir -p docs/resources
+            echo "# Shared Storage\n\n- Group folder: ${BASE}/${GROUP_ID}\n" > docs/resources/storage.md
+            echo "has_storage=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_storage=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Replace placeholders in mkdocs.yml and docs
+        run: |
+          TITLE="${{ steps.names.outputs.title }}"
+          SITE_URL="${{ steps.names.outputs.site_url }}"
+          REPO_URL="https://github.com/${{ github.repository }}"
+          # mkdocs.yml
+          if [ -f mkdocs.yml ]; then
+            sed -i.bak "s|^site_name:.*|site_name: \"${TITLE}\"|g" mkdocs.yml || true
+            if grep -q '^site_url:' mkdocs.yml; then
+              sed -i.bak "s|^site_url:.*|site_url: \"${SITE_URL}\"|g" mkdocs.yml || true
+            else
+              printf "\nsite_url: \"%s\"\n" "$SITE_URL" >> mkdocs.yml
+            fi
+          fi
+          # docs/index.md (H1 + resource block)
+          if [ -f docs/index.md ]; then
+            awk 'NR==1{sub(/^# .*/, "# '"${TITLE}"'"); print; next} 1' docs/index.md > docs/index.md.tmp && mv docs/index.md.tmp docs/index.md
+            STORAGE_FLAG="${{ steps.storage.outputs.has_storage }}"
+            if [ "$STORAGE_FLAG" = "true" ]; then
+              perl -0777 -pe "s|<!--RESOURCES_START-->.*<!--RESOURCES_END-->|<!--RESOURCES_START-->\n\n**Repo:** ${REPO_URL}  \\n**Shared storage:** See [resources/storage.md](resources/storage.md)\n\n<!--RESOURCES_END-->|s" -i docs/index.md || \
+              printf "\n\n<!--RESOURCES_START-->\n\n**Repo:** %s  \\n**Shared storage:** See [resources/storage.md](resources/storage.md)\n\n<!--RESOURCES_END-->\n" "$REPO_URL" >> docs/index.md
+            else
+              perl -0777 -pe "s|<!--RESOURCES_START-->.*<!--RESOURCES_END-->|<!--RESOURCES_START-->\n\n**Repo:** ${REPO_URL}\n\n<!--RESOURCES_END-->|s" -i docs/index.md || \
+              printf "\n\n<!--RESOURCES_START-->\n\n**Repo:** %s\n\n<!--RESOURCES_END-->\n" "$REPO_URL" >> docs/index.md
+            fi
+          fi
+
+      - name: Commit bootstrap changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(bootstrap): set site title/urls and resources"
+          commit_user_name: "oasis-bot"
+          commit_user_email: "oasis-bot@users.noreply.github.com"
+          branch: main
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build site with MkDocs
+        run: |
+          pipx install mkdocs-material
+          mkdocs build --strict --verbose
+        env:
+          PYTHONWARNINGS: ignore
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to Pages
+        uses: actions/deploy-pages@v4
+
+      - name: Open a “Setup complete” issue
+        if: always()
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "✅ Repo bootstrap complete"
+          content-filepath: .github/ISSUE_TEMPLATES/SETUP_COMPLETE.md
+          labels: setup

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,20 @@
+name: Deploy site (MkDocs)
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  pages: write
+  id-token: write
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - run: pipx install mkdocs-material && mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v3
+        with: { path: site }
+      - uses: actions/deploy-pages@v4

--- a/TEMPLATE_GUIDE.md
+++ b/TEMPLATE_GUIDE.md
@@ -33,3 +33,9 @@ This repository is a template for new project groups. After cloning or copying i
 - After committing changes, confirm the site builds at your updated `site_url`.
 
 Work through this list before adding new content. Keep this file for future reference or remove it after setup.
+
+## Automation (first run)
+After you create a repo from this template:
+1. Go to **Actions → Bootstrap new repo → Run workflow** (if it didn’t run automatically).
+2. (Optional) In **Settings → Secrets and variables → Actions**, add a secret named `COMMUNITY_STORAGE_BASE` with your base path (e.g., `i:/iplant/home/shared/earthlab/esiil-community/Innovation-Summit-2025/groups`). If your repo name ends with `__<number>`, we’ll link to `${COMMUNITY_STORAGE_BASE}/<number>`.
+3. Your site will publish to `https://<org>.github.io/<repo>/` when the workflow completes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,19 +1,17 @@
----
-layout: page
-title: Project Sprint — 3-Day Science Showcase
-permalink: /
----
+# Project Title
+
+<!--RESOURCES_START-->
+(This block will be updated automatically on first run.)
+<!--RESOURCES_END-->
 
 <p style="text-align: right;"><a href="https://github.com/CU-ESIIL/Project_group_OASIS/edit/main/docs/index.md" title="Edit this page">✏️</a></p>
- 
+
 <!-- =========================================================
 HERO (Swap hero.jpg, title, strapline, and the three links)
 ========================================================= -->
 
 ![Wide banner of the study system](assets/hero.jpg)
 [Raw photo location: hero.jpg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/hero.jpg)
-
-# Project Sprint: Clear, Short Title 📣 
 
 **One sentence on impact:** In 3 days, we explore *X* to inform *Y*, producing actionable visuals, a concise brief, and shareable code.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
-site_name: 'ESIIL Project Group OASIS'
+site_name: "Project Title"
 site_description: 'Central resource for ESIIL project groups'
 site_author: Ty Tuff
-site_url: https://cu-esiil.github.io/Project_group_home
+site_url: "https://OWNER.github.io/REPO/"
 
 # Repository
 repo_name: Project-group-home


### PR DESCRIPTION
## Summary
- add a bootstrap workflow to derive site metadata, wire optional storage links, auto-commit, and deploy to Pages
- provide a companion MkDocs deployment workflow and setup-complete issue template for new repos
- update mkdocs defaults, docs/index.md resource block, and template guide automation instructions

## Testing
- mkdocs build --strict *(fails: existing documentation references missing pages and assets, causing strict mode warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68cda4405c648325b2278fa3b91ae77b