### PR TITLE
Fix GitHub Pages workflow for MkDocs deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,8 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - uses: actions/configure-pages@v5
-      - run: pipx install mkdocs-material && mkdocs build --strict
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Build site
+        run: mkdocs build --strict
       - uses: actions/upload-pages-artifact@v3
         with: { path: site }
       - uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- ensure the GitHub Pages workflow sets up Python 3.11 before building the documentation
- install the MkDocs requirements with pip instead of pipx so the strict build succeeds

## Testing
- pip install -r requirements.txt && mkdocs build --strict *(fails: proxy blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cdac95739c8325b4cd0072df543a3f