### PR TITLE
Add persistent storage link to navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
   - Storage:
       - Your code: https://github.com/CU-ESIIL/Project_group_OASIS/tree/main/code
       - Your documentation: https://github.com/CU-ESIIL/Project_group_OASIS/tree/main/documentation
+      - Your persistent storage: /iplant/home/shared/esiil/Innovation_summit/Group_1
   - Orientation:
       - Summit slides: orientation/slides.md
       - ESIIL training: orientation/esiil_training.md


### PR DESCRIPTION
## Summary
- add a persistent storage entry to the Storage navigation section that links to the team’s shared CyVerse path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdc5bfbb608325b7869ed1013e6a63