### PR TITLE
Fix persistent storage navigation link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ nav:
   - Storage:
       - Your code: https://github.com/CU-ESIIL/Project_group_OASIS/tree/main/code
       - Your documentation: https://github.com/CU-ESIIL/Project_group_OASIS/tree/main/documentation
-      - Your persistent storage: /iplant/home/shared/esiil/Innovation_summit/Group_1
+      - Your persistent storage: "https://de.cyverse.org/data/ds/iplant/home/shared/esiil/Innovation_summit/Group_1?type=folder&resourceId=1993057e-8e90-11f0-b0fa-90e2ba675364"
   - Orientation:
       - Summit slides: orientation/slides.md
       - ESIIL training: orientation/esiil_training.md


### PR DESCRIPTION
## Summary
- update the Storage navigation entry for persistent storage to point at the CyVerse Data Store folder

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdc73075548325ae57ce46b7ee42f1