### PR TITLE
Replace orientation screenshots with SVG placeholders

### DIFF
--- a/docs/assets/cyverse_basics/README.md
+++ b/docs/assets/cyverse_basics/README.md
@@ -1,0 +1,3 @@
+# CyVerse Basics Placeholder Assets
+
+This directory contains lightweight SVG illustrations that act as stand-ins for the screenshots referenced by `docs/orientation/cyverse_basics.md`. Swap any file with a real screenshot—keeping the original filename—to refresh the guide without breaking links.

--- a/docs/assets/cyverse_basics/app_launch.svg
+++ b/docs/assets/cyverse_basics/app_launch.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='app_launch-title app_launch-desc'>
+  <title id='app_launch-title'>Configure analysis</title>
+  <desc id='app_launch-desc'>Launch settings screen with disk size and resource options for the CyVerse analysis.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Configure analysis</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Launch settings screen with disk size and</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">resource options for the CyVerse analysis.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace app_launch.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/app_settings.svg
+++ b/docs/assets/cyverse_basics/app_settings.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='app_settings-title app_settings-desc'>
+  <title id='app_settings-title'>Analysis options</title>
+  <desc id='app_settings-desc'>Expanded configuration card that lists advanced resource settings prior to launching.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Analysis options</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Expanded configuration card that lists</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">advanced resource settings prior to launching.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace app_settings.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/apps.svg
+++ b/docs/assets/cyverse_basics/apps.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='apps-title apps-desc'>
+  <title id='apps-title'>Apps navigation</title>
+  <desc id='apps-desc'>Screenshot of the Apps navigation panel in the CyVerse Discovery Environment.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Apps navigation</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Screenshot of the Apps navigation panel in the</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">CyVerse Discovery Environment.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace apps.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/click_cyverse_utils.svg
+++ b/docs/assets/cyverse_basics/click_cyverse_utils.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='click_cyverse_utils-title click_cyverse_utils-desc'>
+  <title id='click_cyverse_utils-title'>Open cyverse-utils</title>
+  <desc id='click_cyverse_utils-desc'>Instruction to expand the cyverse-utils directory within the JupyterLab file explorer.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Open cyverse-utils</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Instruction to expand the cyverse-utils</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">directory within the JupyterLab file explorer.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace click_cyverse_utils.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/clone.svg
+++ b/docs/assets/cyverse_basics/clone.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='clone-title clone-desc'>
+  <title id='clone-title'>Clone repository</title>
+  <desc id='clone-desc'>Git extension modal used to paste a repository URL before cloning.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Clone repository</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Git extension modal used to paste a repository</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">URL before cloning.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace clone.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/cyverse-utils.svg
+++ b/docs/assets/cyverse_basics/cyverse-utils.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='cyverse-utils-title cyverse-utils-desc'>
+  <title id='cyverse-utils-title'>Repository in sidebar</title>
+  <desc id='cyverse-utils-desc'>File browser displaying the cyverse-utils folder after cloning the repository.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Repository in sidebar</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">File browser displaying the cyverse-utils</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">folder after cloning the repository.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace cyverse-utils.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/email.svg
+++ b/docs/assets/cyverse_basics/email.svg
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='email-title email-desc'>
+  <title id='email-title'>Enter email</title>
+  <desc id='email-desc'>Prompt showing the input field where the GitHub email address is entered in the notebook.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Enter email</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Prompt showing the input field where the</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">GitHub email address is entered in the</text>
+  <text x="480" y="344" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">notebook.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace email.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/final.svg
+++ b/docs/assets/cyverse_basics/final.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='final-title final-desc'>
+  <title id='final-title'>Key added</title>
+  <desc id='final-desc'>Confirmation page showing the SSH key in the authentication keys list.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Key added</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Confirmation page showing the SSH key in the</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">authentication keys list.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace final.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/go_to_analysis.svg
+++ b/docs/assets/cyverse_basics/go_to_analysis.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='go_to_analysis-title go_to_analysis-desc'>
+  <title id='go_to_analysis-title'>Go to analysis</title>
+  <desc id='go_to_analysis-desc'>Notification banner prompting the user to open the running analysis session.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Go to analysis</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Notification banner prompting the user to open</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">the running analysis session.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace go_to_analysis.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/jupyterlab.svg
+++ b/docs/assets/cyverse_basics/jupyterlab.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='jupyterlab-title jupyterlab-desc'>
+  <title id='jupyterlab-title'>JupyterLab interface</title>
+  <desc id='jupyterlab-desc'>Workspace view after the CyVerse analysis launches, showing the JupyterLab UI.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>JupyterLab interface</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Workspace view after the CyVerse analysis</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">launches, showing the JupyterLab UI.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace jupyterlab.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/key.svg
+++ b/docs/assets/cyverse_basics/key.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='key-title key-desc'>
+  <title id='key-title'>Copy SSH key</title>
+  <desc id='key-desc'>Notebook cell displaying the generated public SSH key ready to copy.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Copy SSH key</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Notebook cell displaying the generated public</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">SSH key ready to copy.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace key.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/launch.svg
+++ b/docs/assets/cyverse_basics/launch.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='launch-title launch-desc'>
+  <title id='launch-title'>Launch analysis</title>
+  <desc id='launch-desc'>Launch button confirmation inside the CyVerse interface before the environment starts.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Launch analysis</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Launch button confirmation inside the CyVerse</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">interface before the environment starts.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace launch.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/new_key.svg
+++ b/docs/assets/cyverse_basics/new_key.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='new_key-title new_key-desc'>
+  <title id='new_key-title'>New SSH key</title>
+  <desc id='new_key-desc'>Button to create a new SSH key within GitHub account settings.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>New SSH key</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Button to create a new SSH key within GitHub</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">account settings.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace new_key.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/open_cyverse_utils.svg
+++ b/docs/assets/cyverse_basics/open_cyverse_utils.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='open_cyverse_utils-title open_cyverse_utils-desc'>
+  <title id='open_cyverse_utils-title'>Open keypair notebook</title>
+  <desc id='open_cyverse_utils-desc'>File detail view illustrating the create_github_keypair notebook ready to open.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Open keypair notebook</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">File detail view illustrating the</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">create_github_keypair notebook ready to open.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace open_cyverse_utils.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/paste_key.svg
+++ b/docs/assets/cyverse_basics/paste_key.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='paste_key-title paste_key-desc'>
+  <title id='paste_key-title'>Paste SSH key</title>
+  <desc id='paste_key-desc'>Form fields for naming and pasting the newly generated public key on GitHub.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Paste SSH key</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Form fields for naming and pasting the newly</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">generated public key on GitHub.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace paste_key.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/script_1.svg
+++ b/docs/assets/cyverse_basics/script_1.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='script_1-title script_1-desc'>
+  <title id='script_1-title'>Run setup notebook</title>
+  <desc id='script_1-desc'>Notebook cell output prompting for GitHub username and email while generating keys.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Run setup notebook</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Notebook cell output prompting for GitHub</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">username and email while generating keys.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace script_1.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/settings.svg
+++ b/docs/assets/cyverse_basics/settings.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='settings-title settings-desc'>
+  <title id='settings-title'>GitHub settings</title>
+  <desc id='settings-desc'>GitHub account settings page with the sidebar navigation highlighted.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>GitHub settings</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">GitHub account settings page with the sidebar</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">navigation highlighted.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace settings.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/ssh.svg
+++ b/docs/assets/cyverse_basics/ssh.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='ssh-title ssh-desc'>
+  <title id='ssh-title'>SSH keys menu</title>
+  <desc id='ssh-desc'>GitHub SSH and GPG keys section listing existing keys.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>SSH keys menu</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">GitHub SSH and GPG keys section listing</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">existing keys.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace ssh.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/use_this_app.svg
+++ b/docs/assets/cyverse_basics/use_this_app.svg
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='use_this_app-title use_this_app-desc'>
+  <title id='use_this_app-title'>Select JupyterLab app</title>
+  <desc id='use_this_app-desc'>Dialog showing the JupyterLab ESIIL application tile highlighted for launching an analysis.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Select JupyterLab app</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Dialog showing the JupyterLab ESIIL</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">application tile highlighted for launching an</text>
+  <text x="480" y="344" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">analysis.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace use_this_app.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/cyverse_basics/username.svg
+++ b/docs/assets/cyverse_basics/username.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='username-title username-desc'>
+  <title id='username-title'>Enter username</title>
+  <desc id='username-desc'>Prompt showing the input field where the GitHub username is entered in the notebook.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Enter username</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Prompt showing the input field where the</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">GitHub username is entered in the notebook.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace username.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/docker_basics/README.md
+++ b/docs/assets/docker_basics/README.md
@@ -1,0 +1,3 @@
+# Docker Basics Placeholder Assets
+
+These SVG illustrations correspond to the screenshots referenced in `docs/orientation/docker_basics.md`. Replace any file with a real CyVerse or GitHub interface capture—while keeping the filename—to update the walkthrough without modifying the Markdown.

--- a/docs/assets/docker_basics/actions.svg
+++ b/docs/assets/docker_basics/actions.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='actions-title actions-desc'>
+  <title id='actions-title'>GitHub Actions tab</title>
+  <desc id='actions-desc'>GitHub repository navigation showing the Actions tab selected.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>GitHub Actions tab</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">GitHub repository navigation showing the</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Actions tab selected.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace actions.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/docker_basics/add_tool.svg
+++ b/docs/assets/docker_basics/add_tool.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='add_tool-title add_tool-desc'>
+  <title id='add_tool-title'>Add tool</title>
+  <desc id='add_tool-desc'>Dialog or button for adding a new tool inside the CyVerse interface.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Add tool</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Dialog or button for adding a new tool inside</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">the CyVerse interface.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace add_tool.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/docker_basics/app_name.svg
+++ b/docs/assets/docker_basics/app_name.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='app_name-title app_name-desc'>
+  <title id='app_name-title'>App details</title>
+  <desc id='app_name-desc'>Fields for entering the app name and description during creation.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>App details</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Fields for entering the app name and</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">description during creation.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace app_name.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/docker_basics/container_port.svg
+++ b/docs/assets/docker_basics/container_port.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='container_port-title container_port-desc'>
+  <title id='container_port-title'>Container port</title>
+  <desc id='container_port-desc'>Section where container port 8888 is added along with working directory details.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Container port</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Section where container port 8888 is added</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">along with working directory details.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace container_port.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/docker_basics/create_app.svg
+++ b/docs/assets/docker_basics/create_app.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='create_app-title create_app-desc'>
+  <title id='create_app-title'>Create app</title>
+  <desc id='create_app-desc'>Button used to create a new app from the CyVerse Apps dashboard.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Create app</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Button used to create a new app from the</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">CyVerse Apps dashboard.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace create_app.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/docker_basics/dockerhub.svg
+++ b/docs/assets/docker_basics/dockerhub.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='dockerhub-title dockerhub-desc'>
+  <title id='dockerhub-title'>DockerHub reference</title>
+  <desc id='dockerhub-desc'>DockerHub repository view showing the image tags required for the app.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>DockerHub reference</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">DockerHub repository view showing the image</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">tags required for the app.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace dockerhub.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/docker_basics/image_name.svg
+++ b/docs/assets/docker_basics/image_name.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='image_name-title image_name-desc'>
+  <title id='image_name-title'>Docker image settings</title>
+  <desc id='image_name-desc'>Fields specifying the Docker image name and tag for the CyVerse tool.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Docker image settings</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Fields specifying the Docker image name and</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">tag for the CyVerse tool.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace image_name.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/docker_basics/manage_tools.svg
+++ b/docs/assets/docker_basics/manage_tools.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='manage_tools-title manage_tools-desc'>
+  <title id='manage_tools-title'>CyVerse manage tools</title>
+  <desc id='manage_tools-desc'>CyVerse Manage Tools page reached from the Apps dashboard.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>CyVerse manage tools</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">CyVerse Manage Tools page reached from the</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Apps dashboard.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace manage_tools.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/docker_basics/restrictions.svg
+++ b/docs/assets/docker_basics/restrictions.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='restrictions-title restrictions-desc'>
+  <title id='restrictions-title'>Restrictions settings</title>
+  <desc id='restrictions-desc'>Form section for specifying app access restrictions before saving.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Restrictions settings</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Form section for specifying app access</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">restrictions before saving.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace restrictions.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/docker_basics/run_workflow.svg
+++ b/docs/assets/docker_basics/run_workflow.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='run_workflow-title run_workflow-desc'>
+  <title id='run_workflow-title'>Run workflow</title>
+  <desc id='run_workflow-desc'>Dropdown for manually triggering the workflow from the GitHub Actions interface.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Run workflow</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Dropdown for manually triggering the workflow</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">from the GitHub Actions interface.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace run_workflow.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/docker_basics/save_and_launch.svg
+++ b/docs/assets/docker_basics/save_and_launch.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='save_and_launch-title save_and_launch-desc'>
+  <title id='save_and_launch-title'>Save and launch</title>
+  <desc id='save_and_launch-desc'>Final confirmation page prompting Save and Launch for the app.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Save and launch</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Final confirmation page prompting Save and</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Launch for the app.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace save_and_launch.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/docker_basics/tool_name.svg
+++ b/docs/assets/docker_basics/tool_name.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='tool_name-title tool_name-desc'>
+  <title id='tool_name-title'>Tool details</title>
+  <desc id='tool_name-desc'>Form fields used to enter the tool name and version when registering an image.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Tool details</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Form fields used to enter the tool name and</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">version when registering an image.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace tool_name.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/docker_basics/tool_search.svg
+++ b/docs/assets/docker_basics/tool_search.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='tool_search-title tool_search-desc'>
+  <title id='tool_search-title'>Select tool</title>
+  <desc id='tool_search-desc'>Search dialog for choosing the tool that powers the new app.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Select tool</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Search dialog for choosing the tool that</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">powers the new app.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace tool_search.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/docker_basics/workflows.svg
+++ b/docs/assets/docker_basics/workflows.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='workflows-title workflows-desc'>
+  <title id='workflows-title'>Workflow list</title>
+  <desc id='workflows-desc'>Panel listing available GitHub workflows with the build pipeline highlighted.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Workflow list</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Panel listing available GitHub workflows with</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">the build pipeline highlighted.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace workflows.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/template/README.md
+++ b/docs/assets/template/README.md
@@ -1,0 +1,3 @@
+# Template Asset Placeholders
+
+The hero and team logo illustrations in this folder are SVG stand-ins that keep the project template looking polished out of the box. Replace them with project-specific artwork—preserving the filenames—to personalize `docs/project_template.md`.

--- a/docs/assets/template/hero.svg
+++ b/docs/assets/template/hero.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='hero-title hero-desc'>
+  <title id='hero-title'>Team hero banner</title>
+  <desc id='hero-desc'>Wide hero artwork used at the top of the project template landing page.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Team hero banner</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Wide hero artwork used at the top of the</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">project template landing page.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace hero.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/assets/template/team-logo.svg
+++ b/docs/assets/template/team-logo.svg
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns='http://www.w3.org/2000/svg' width='960' height='540' viewBox='0 0 960 540' role='img' aria-labelledby='team-logo-title team-logo-desc'>
+  <title id='team-logo-title'>Team logo</title>
+  <desc id='team-logo-desc'>Square team logo displayed alongside the project details in the template.</desc>
+  <rect width='940' height='520' x='10' y='10' rx='24' ry='24' fill='#eef2ff' stroke='#4f46e5' stroke-width='4'/>
+  <text x='480' y='140' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='28' fill='#312e81'>Documentation Placeholder</text>
+  <text x='480' y='210' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='42' font-weight='bold' fill='#1e1b4b'>Team logo</text>
+  <text x="480" y="280" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">Square team logo displayed alongside the</text>
+  <text x="480" y="312" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#1f2937">project details in the template.</text>
+  <text x='480' y='470' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='18' fill='#4338ca'>Replace team-logo.svg with a real screenshot to update the guide.</text>
+</svg>

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,3 @@
+# Data Access Placeholder
+
+This page is reserved for documenting project datasets. Update it with links, access instructions, and any notes relevant to your team.

--- a/docs/orientation/cyverse_basics.md
+++ b/docs/orientation/cyverse_basics.md
@@ -24,31 +24,34 @@
 
 ## Open up an analysis with the hackathon environment (Jupyter Lab)
 
+!!! note "Illustrative placeholders"
+    The figures embedded in the steps below are lightweight SVG placeholders so the documentation builds without missing-asset warnings. Replace the matching files in `docs/assets/cyverse_basics/` with real screenshots whenever updated imagery is available.
+
 1. From the Cyverse Discovery Environment, click on `Apps` in the left menu
-   ![apps](../assets/cyverse_basics/apps.png)
-[Raw photo location: apps.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/apps.png)
+   ![apps](../assets/cyverse_basics/apps.svg)
+   [Raw photo location: apps.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/apps.svg)
 
 2. Select `JupyterLab ESIIL`
-   ![use_this_app](../assets/cyverse_basics/use_this_app.png)
-[Raw photo location: use_this_app.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/use_this_app.png)
+   ![use_this_app](../assets/cyverse_basics/use_this_app.svg)
+[Raw photo location: use_this_app.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/use_this_app.svg)
 
 3. Configure and launch your analysis - when choosing the disk size, make sure to choose 64GB or greater. The rest of the settings you can change to suit your computing needs:
-   ![app_launch](../assets/cyverse_basics/app_launch.png)
-[Raw photo location: app_launch.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/app_launch.png)
+   ![app_launch](../assets/cyverse_basics/app_launch.svg)
+[Raw photo location: app_launch.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/app_launch.svg)
 
-   ![app_settings](../assets/cyverse_basics/app_settings.png)
-[Raw photo location: app_settings.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/app_settings.png)
+   ![app_settings](../assets/cyverse_basics/app_settings.svg)
+[Raw photo location: app_settings.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/app_settings.svg)
 
-   ![launch](../assets/cyverse_basics/launch.png)
-[Raw photo location: launch.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/launch.png)
+   ![launch](../assets/cyverse_basics/launch.svg)
+[Raw photo location: launch.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/launch.svg)
 
 4. Click `Go to analysis`:
-   ![go_to_analysis](../assets/cyverse_basics/go_to_analysis.png)
-[Raw photo location: go_to_analysis.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/go_to_analysis.png)
+   ![go_to_analysis](../assets/cyverse_basics/go_to_analysis.svg)
+[Raw photo location: go_to_analysis.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/go_to_analysis.svg)
 
 5. Now you should see Jupyter Lab!
-   ![jupyterlab](../assets/cyverse_basics/jupyterlab.png)
-[Raw photo location: jupyterlab.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/jupyterlab.png)
+   ![jupyterlab](../assets/cyverse_basics/jupyterlab.svg)
+[Raw photo location: jupyterlab.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/jupyterlab.svg)
 
 ## Set up your GitHub credentials
 
@@ -58,57 +61,57 @@
 </a>
 
 1. From Jupyter Lab, click on the Git Extension icon on the left menu:
-   ![jupyterlab](../assets/cyverse_basics/jupyterlab.png)
-[Raw photo location: jupyterlab.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/jupyterlab.png)
+   ![jupyterlab](../assets/cyverse_basics/jupyterlab.svg)
+[Raw photo location: jupyterlab.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/jupyterlab.svg)
 
 2. Click `Clone a Repository` and Paste the link to the cyverse-utils [https://github.com/CU-ESIIL/cyverse-utils.git](https://github.com/CU-ESIIL/cyverse-utils.git) and click `Clone`:
-   ![clone](../assets/cyverse_basics/clone.png)
-[Raw photo location: clone.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/clone.png)
+   ![clone](../assets/cyverse_basics/clone.svg)
+[Raw photo location: clone.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/clone.svg)
    
 3. You should now see the `cyverse-utils` folder in your directory tree (provided you haven't changed directories from the default `/home/jovyan/data-store`
-   ![cyverse-utils](../assets/cyverse_basics/cyverse-utils.png)
-[Raw photo location: cyverse-utils.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/cyverse-utils.png)
+   ![cyverse-utils](../assets/cyverse_basics/cyverse-utils.svg)
+[Raw photo location: cyverse-utils.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/cyverse-utils.svg)
 
 4. Go into the `cyverse-utils` folder:
-   ![click_cyverse_utils](../assets/cyverse_basics/click_cyverse_utils.png)
-[Raw photo location: click_cyverse_utils.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/click_cyverse_utils.png)
+   ![click_cyverse_utils](../assets/cyverse_basics/click_cyverse_utils.svg)
+[Raw photo location: click_cyverse_utils.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/click_cyverse_utils.svg)
 
 5. open up the `create_github_keypair.ipynb` notebook if you prefer Python or the 'create_github_keypair.R' script if you prefer R by double-clicking and then select the default 'macrosystems' kernel:
-![open_cyverse_utils](../assets/cyverse_basics/open_cyverse_utils.png)
-[Raw photo location: open_cyverse_utils.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/open_cyverse_utils.png)
+![open_cyverse_utils](../assets/cyverse_basics/open_cyverse_utils.svg)
+[Raw photo location: open_cyverse_utils.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/open_cyverse_utils.svg)
 
 6. Now you should see the notebook open. Click the `play` button at the top. You will be prompted to enter your GitHub username and email:
-   ![script_1](../assets/cyverse_basics/script_1.png)
-[Raw photo location: script_1.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/script_1.png)
+   ![script_1](../assets/cyverse_basics/script_1.svg)
+[Raw photo location: script_1.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/script_1.svg)
 
-   ![username](../assets/cyverse_basics/username.png)
-[Raw photo location: username.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/username.png)
+   ![username](../assets/cyverse_basics/username.svg)
+[Raw photo location: username.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/username.svg)
 
-   ![email](../assets/cyverse_basics/email.png)
-[Raw photo location: email.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/email.png)
+   ![email](../assets/cyverse_basics/email.svg)
+[Raw photo location: email.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/email.svg)
 
 7. You should now see your Public Key. Copy the WHOLE LINE including `ssh-ed25519` at the beginning and the `jovyan@...` at the end
-![key](../assets/cyverse_basics/key.png)
-[Raw photo location: key.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/key.png)
+![key](../assets/cyverse_basics/key.svg)
+[Raw photo location: key.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/key.svg)
 
 8. Go to your GitHub settings page (you may need to log in to GitHub first):
-   ![settings](../assets/cyverse_basics/settings.png)
-[Raw photo location: settings.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/settings.png)
+   ![settings](../assets/cyverse_basics/settings.svg)
+[Raw photo location: settings.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/settings.svg)
 
 9. Select `SSH and GPG keys`
-   ![ssh](../assets/cyverse_basics/ssh.png)
-[Raw photo location: ssh.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/ssh.png)
+   ![ssh](../assets/cyverse_basics/ssh.svg)
+[Raw photo location: ssh.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/ssh.svg)
 
 10. Select `New SSH key`
-   ![new_key](../assets/cyverse_basics/new_key.png)
-[Raw photo location: new_key.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/new_key.png)
+   ![new_key](../assets/cyverse_basics/new_key.svg)
+[Raw photo location: new_key.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/new_key.svg)
 
 11. Give your key a descriptive name, paste your ENTIRE public key in the `Key` input box, and click `Add SSH Key`. You may need to re-authenticate with your password or two-factor authentication.:
-   ![paste_key](../assets/cyverse_basics/paste_key.png)
-[Raw photo location: paste_key.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/paste_key.png)
+   ![paste_key](../assets/cyverse_basics/paste_key.svg)
+[Raw photo location: paste_key.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/paste_key.svg)
 
 12. You should now see your new SSH key in your `Authentication Keys` list! Now you will be able to clone private repositories and push changes to GitHub from your Cyverse analysis!
-   ![final](../assets/cyverse_basics/final.png)
-[Raw photo location: final.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/final.png)
+   ![final](../assets/cyverse_basics/final.svg)
+[Raw photo location: final.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/cyverse_basics/final.svg)
 
 > NOTE! Your GitHub authentication is ONLY for the analysis you're working with right now. You will be able to use it as long as you want there, but once you start a new analysis you will need to go through this process again. Feel free to delete keys from old analyses that have been shut down.

--- a/docs/orientation/docker_basics.md
+++ b/docs/orientation/docker_basics.md
@@ -216,77 +216,80 @@ jobs:
 The steps section of the file defines what will be run by the Action. An overview of the steps of this file is as follows: Checkout the repository code, setup Docker buildx, login to DockerHub, resolve the name of the current GitHub reposiroy, build and push the Docker Image to DockerHub.
 
 ### Running the Action
-From your repositories GitHub page, click on the Actions tab 
-![Actions](../assets/docker_basics/actions.png)
-[Raw photo location: actions.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/actions.png)
+!!! note "Screenshot placeholders"
+    The images that follow are SVG placeholders to keep the guide lint-clean. Replace the corresponding files in `docs/assets/docker_basics/` with real workflow captures when you have them.
+
+From your repositories GitHub page, click on the Actions tab
+![Actions](../assets/docker_basics/actions.svg)
+[Raw photo location: actions.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/actions.svg)
 
 Find the workflow in the Workflow navigation menu and click on it
-![Workflows](../assets/docker_basics/workflows.png)
-[Raw photo location: workflows.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/workflows.png)
+![Workflows](../assets/docker_basics/workflows.svg)
+[Raw photo location: workflows.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/workflows.svg)
 
 Click on the run workflow dropdown and click Run Workflow
-![RunWorkflow](../assets/docker_basics/run_workflow.png)
-[Raw photo location: run_workflow.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/run_workflow.png)
+![RunWorkflow](../assets/docker_basics/run_workflow.svg)
+[Raw photo location: run_workflow.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/run_workflow.svg)
 
 ## Deploying the Image on CyVerse
 First go to de.cyverse.org and login. From there go to the Apps dashboard and click on Manage Tools.
 
 [![Launch in CyVerse DE](https://img.shields.io/badge/Launch-CyVerse%20DE-0b6efd?style=flat-square)](https://de.cyverse.org/apps/de/faf1d268-44cc-11ed-9715-008cfa5ae621/launch?saved-launch-id=dc65718e-1964-4d11-99ad-bf901cddda99)
 
-![ManageTools](../assets/docker_basics/manage_tools.png)
-[Raw photo location: manage_tools.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/manage_tools.png)
+![ManageTools](../assets/docker_basics/manage_tools.svg)
+[Raw photo location: manage_tools.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/manage_tools.svg)
 
 ### Adding the Image as a Tool
 Then click Add Tool.
 
-![AddTool](../assets/docker_basics/add_tool.png)
-[Raw photo location: add_tool.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/add_tool.png)
+![AddTool](../assets/docker_basics/add_tool.svg)
+[Raw photo location: add_tool.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/add_tool.svg)
 
 Give the Tool a descriptive name and set the initial version. The version can be whatever you like but 1.0 makes the most sense.
 
-![ToolName](../assets/docker_basics/tool_name.png)
-[Raw photo location: tool_name.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/tool_name.png)
+![ToolName](../assets/docker_basics/tool_name.svg)
+[Raw photo location: tool_name.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/tool_name.svg)
 
 Set the Image Name to esiil/name_of_your_image and the tag to whichever tag you would like the Tool to use. Most Tools will use the latest tag.
 
-![ImageName](../assets/docker_basics/image_name.png)
-[Raw photo location: image_name.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/image_name.png)
+![ImageName](../assets/docker_basics/image_name.svg)
+[Raw photo location: image_name.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/image_name.svg)
 
 You can see all of this information on the ESIIL dockerhub page.
 
-![DockerHub](../assets/docker_basics/dockerhub.png)
-[Raw photo location: dockerhub.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/dockerhub.png)
+![DockerHub](../assets/docker_basics/dockerhub.svg)
+[Raw photo location: dockerhub.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/dockerhub.svg)
 
 Leave the Entrypoint blank, and set the working directory to /home/jovyan/data-store and the UID to 1000. Add container port 8888. This will mount and give you access to the cyverse data store. Because the file explorer GUI will not let you go above the working directory that is set, you will have to use the terminal to go up one directory and copy over any files you included in your container.
 
-![ContainerPort](../assets/docker_basics/container_port.png)
-[Raw photo location: container_port.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/container_port.png)
+![ContainerPort](../assets/docker_basics/container_port.svg)
+[Raw photo location: container_port.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/container_port.svg)
 
 Leave all of the restrictions blank and then save the Tool
 
-![Restrictions](../assets/docker_basics/restrictions.png)
-[Raw photo location: restrictions.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/restrictions.png)
+![Restrictions](../assets/docker_basics/restrictions.svg)
+[Raw photo location: restrictions.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/restrictions.svg)
 
 ### Associating the Tool with an App
 Go back to the Apps dashboard and click create
 
-![CreateApp](../assets/docker_basics/create_app.png)
-[Raw photo location: create_app.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/create_app.png)
+![CreateApp](../assets/docker_basics/create_app.svg)
+[Raw photo location: create_app.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/create_app.svg)
 
 Just like for the Tool, give a descriptive name and description
 
-![AppName](../assets/docker_basics/app_name.png)
-[Raw photo location: app_name.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/app_name.png)
+![AppName](../assets/docker_basics/app_name.svg)
+[Raw photo location: app_name.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/app_name.svg)
 
 For "Tool used" click select and then search for the name of the tool that was just added and then click on its row and then select at the bottom.
 
-![ToolSearch](../assets/docker_basics/tool_search.png)
-[Raw photo location: tool_search.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/tool_search.png)
+![ToolSearch](../assets/docker_basics/tool_search.svg)
+[Raw photo location: tool_search.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/tool_search.svg)
 
 From the app creation screen click Next, and then click next through the next steps until you get to completion. From there click Save and Launch
 
-![SaveandLaunch](../assets/docker_basics/save_and_launch.png)
-[Raw photo location: save_and_launch.png](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/save_and_launch.png)
+![SaveandLaunch](../assets/docker_basics/save_and_launch.svg)
+[Raw photo location: save_and_launch.svg](https://github.com/CU-ESIIL/Project_group_OASIS/blob/main/docs/assets/docker_basics/save_and_launch.svg)
 
 From there you can go through the deployment of your app like you would deploy any other app on CyVerse and test it out.
 

--- a/docs/project_template.md
+++ b/docs/project_template.md
@@ -2,8 +2,8 @@
 layout: default
 title: "OASIS: 3-Day Team Template"
 subtitle: "A friction-free guide for collaborative research sprints"
-hero_image: assets/template/hero.jpg
-team_logo: assets/template/team-logo.png
+hero_image: assets/template/hero.svg
+team_logo: assets/template/team-logo.svg
 contact_slack: "#oasis-project-room"
 contact_email: "team@example.org"
 repo_owner: "cu-esiil"
@@ -16,13 +16,13 @@ edit_path: "docs/project_template.md"
 {{ page.subtitle }}
 
 {% if page.hero_image %}
-![Hero Image]({{ page.hero_image }})
+<img src="{{ page.hero_image }}" alt="Hero Image" />
 {% else %}
 <div style="width:100%;height:200px;background:#eee;display:flex;align-items:center;justify-content:center;">Set `hero_image` in front matter</div>
 {% endif %}
 
 {% if page.team_logo %}
-![Team Logo]({{ page.team_logo }})
+<img src="{{ page.team_logo }}" alt="Team Logo" />
 {% endif %}
 
 [✏️ Edit this page](https://github.com/{{ page.repo_owner }}/{{ page.repo_name }}/edit/main/{{ page.edit_path }})  


### PR DESCRIPTION
## Summary
- swap the CyVerse basics walkthrough images to inline SVG placeholders and call out that the figures are temporary stand-ins
- mirror the SVG placeholder approach for the Docker basics guide so strict MkDocs builds no longer warn about missing assets
- document how to replace the placeholder graphics and convert the project template hero/logo assets to lightweight SVGs

## Testing
- mkdocs build --strict

------
https://chatgpt.com/codex/tasks/task_e_68cdc7f12af48325a09d14813ce28ff4