### PR TITLE
Configure Pages deployment environment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -23,4 +26,5 @@ jobs:
         run: mkdocs build --strict
       - uses: actions/upload-pages-artifact@v3
         with: { path: site }
-      - uses: actions/deploy-pages@v4
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- define the GitHub Pages environment for the deployment job
- expose the deployment URL from the deploy-pages step

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cdccb0cb708325992281b583522451