### PR TITLE
Fix GitHub Pages deployment token configuration

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,21 +1,28 @@
- name: Publish docs via GitHub
- on:
-   push:
-     branches:
-       - main
+name: Publish docs via GitHub
 
- jobs:
-   build:
-     name: Deploy docs
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/checkout@v4
-       - uses: actions/setup-python@v5
-         with:
-           python-version: '3.11'
-       - name: run requirements file
-         run:  pip install -r requirements.txt 
-       - name: Deploy docs
-         run: mkdocs gh-deploy --force
-         env:
-           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install requirements
+        run: pip install -r requirements.txt
+      - name: Deploy docs
+        run: mkdocs gh-deploy --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'


### PR DESCRIPTION
## Summary
- allow the gh-pages workflow to push by using the built-in `GITHUB_TOKEN`, granting write permissions, and fetching the full git history
- fetch the full git history in the Pages deployment workflow so the revision date plugin can resolve file metadata reliably

## Testing
- mkdocs build --strict

------
https://chatgpt.com/codex/tasks/task_e_68cdce2f803c8325b0978a6d33baf646