### PR TITLE
Silence MkDocs nav warnings for non-menu documents

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,18 @@ nav:
       - Code of conduct: orientation/code-of-conduct.md
       - Participant agreement: orientation/participant_agreement.md
 
+not_in_nav: |
+  data.md
+  instructions.md
+  project_template.md
+  assets/cyverse_basics/README.md
+  assets/docker_basics/README.md
+  assets/template/README.md
+  orientation/art_gallery.md
+  orientation/cyverse_basics.md
+  orientation/docker_basics.md
+  orientation/markdown_basics.md
+
 # Configuration
 theme:
   highlightjs: true


### PR DESCRIPTION
## Summary
- mark template and orientation reference pages as intentionally omitted from the navigation
- eliminates MkDocs strict-mode warnings so the Pages workflow can succeed again

## Testing
- mkdocs build --strict

------
https://chatgpt.com/codex/tasks/task_e_68cdd05093a88325a70ec8ee3615d786