### PR TITLE
Remove placeholder resources note from home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,6 @@
 # Project Title
 
 <!--RESOURCES_START-->
-(This block will be updated automatically on first run.)
 <!--RESOURCES_END-->
 
 <p style="text-align: right;"><a href="https://github.com/CU-ESIIL/Project_group_OASIS/edit/main/docs/index.md" title="Edit this page">✏️</a></p>


### PR DESCRIPTION
## Summary
- remove the placeholder notice from the resources block on the documentation home page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ced15cd4188325803c36d541ab17d8