### PR TITLE
Ensure Pages workflow deploys within a single job

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,33 +16,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+
       - name: Install dependencies
         run: pip install -r requirements.txt
+
       - name: Configure Pages
         uses: actions/configure-pages@v5
+
       - name: Build site
         run: mkdocs build --strict --site-dir dist
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist
 
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- run the MkDocs build and Pages deployment in one job so the deploy step remains visible in workflow runs
- keep the GitHub Pages environment context attached to the single job while uploading the build artifact

## Testing
- mkdocs build --strict --site-dir dist

------
https://chatgpt.com/codex/tasks/task_e_68cef02dba9c8325b216159b802ecf23