### PR TITLE
Cleanup: Actions-only GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,11 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-deploy:
+  build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,6 +41,13 @@ jobs:
         with:
           path: dist
 
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- restructure the Pages workflow into separate build and deploy jobs while keeping the configure/upload/deploy steps required for GitHub Pages

## Testing
- not run (workflow change only)

## Notes
- Unable to push the branch or update the github-pages environment via `gh` because outbound HTTPS requests are blocked by a proxy (HTTP 403).


------
https://chatgpt.com/codex/tasks/task_e_68cefc945e1c8325b3bcbb9a5fa78b3c