### PR TITLE
Prepare template-ready GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Deploy Pages
+name: Deploy GitHub Pages
 
 on:
   push:
@@ -30,23 +30,25 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Configure Pages
+      - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Build site
-        run: mkdocs build --strict --site-dir dist
+        run: mkdocs build --strict --site-dir ./dist
 
-      - name: Upload artifact
+      - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: ./dist
 
   deploy:
+    needs: build
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    needs: build
-    runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/TEMPLATE_SETUP.md
+++ b/TEMPLATE_SETUP.md
@@ -1,0 +1,17 @@
+# Template Setup Guide
+
+Welcome! After creating a repository from this template, complete the following steps to ensure your MkDocs site deploys successfully on GitHub Pages.
+
+## Update site metadata
+- Edit `mkdocs.yml` and customize `site_name`, `site_url`, and `repo_url` to match your project.
+
+## Review GitHub Pages environment settings
+- In **Settings → Environments → github-pages**, verify that deployments from the `main` branch (or "All branches") are allowed. Adjust the allowed branches if necessary.
+
+## Confirm organization permissions
+- If you are using this template within an organization that restricts GitHub Actions, ask an administrator to permit Actions for the new repository before triggering the workflow.
+
+## Quick fixes for common errors
+- **Branch not allowed**: Update the allowed branches for the `github-pages` environment so it accepts `main`.
+- **Multiple artifacts uploaded**: Make sure only one Pages artifact is uploaded by your workflow and remove extra upload steps.
+- **Blank site after deployment**: Confirm that `mkdocs build` outputs content into the `dist` directory and that required theme or plugin dependencies are installed.


### PR DESCRIPTION
## Summary
- streamline the GitHub Pages workflow for template-friendly deployment with automatic enablement and mkdocs output in ./dist
- add TEMPLATE_SETUP guidance for customizing site metadata and resolving common Pages errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf2f3c210c832593dc74d03ff8032a