### PR TITLE
Add mkdocs plugins to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ mkdocs-material
 
 # Add each MkDocs plugin or extension referenced in mkdocs.yml below.
 # Example: mkdocs-awesome-plugin
+mkdocstrings[python]
+mkdocs-git-revision-date-plugin
+mkdocs-jupyter


### PR DESCRIPTION
## Summary
- add the mkdocstrings, git-revision-date, and mkdocs-jupyter plugins to the documentation requirements so mkdocs build succeeds

## Testing
- mkdocs build --strict --clean --site-dir dist


------
https://chatgpt.com/codex/tasks/task_e_68d01a6c30e08325acade5333d62d1ef