### PR TITLE
Add missing MkDocs plugin dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ mkdocs-material
 
 # Add each MkDocs plugin or extension referenced in mkdocs.yml below.
 # Example: mkdocs-awesome-plugin
+mkdocstrings[python]
+mkdocs-git-revision-date-plugin
+mkdocs-jupyter


### PR DESCRIPTION
## Summary
- add mkdocstrings, git revision date, and Jupyter plugins to MkDocs requirements

## Testing
- mkdocs build --strict --clean --site-dir dist *(fails: mkdocstrings plugin not available in execution environment due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d01e5ff6a08325a59489960a3bb86e